### PR TITLE
enable Simple Lightbox for Knowledge base plugin

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -238,6 +238,7 @@ class SLB_Lightbox extends SLB_Base {
 				'enabled_page'				=> array('title' => __('Enable on Pages', 'simple-lightbox'), 'default' => true, 'group' => array('activation', 40)),
 				'enabled_archive'			=> array('title' => __('Enable on Archive Pages (tags, categories, etc.)', 'simple-lightbox'), 'default' => true, 'group' => array('activation', 50)),
 				'enabled_widget'			=> array('title' => __('Enable for Widgets', 'simple-lightbox'), 'default' => false, 'group' => array('activation', 60)),
+				'enabled_plugin_knowledgebase'		=> array('title' => __('Enable for plugin Knowledgebase', 'simple-lightbox'), 'default' => false, 'group' => array('activation', 70)),
 				'group_links'				=> array('title' => __('Group items (for displaying as a slideshow)', 'simple-lightbox'), 'default' => true, 'group' => array('grouping', 10)),
 				'group_post'				=> array('title' => __('Group items by Post (e.g. on pages with multiple posts)', 'simple-lightbox'), 'default' => true, 'group' => array('grouping', 20)),
 				'group_gallery'				=> array('title' => __('Group gallery items separately', 'simple-lightbox'), 'default' => false, 'group' => array('grouping', 30)),


### PR DESCRIPTION
I have the plugin PA_Knowledgebase installed (post_type = knowledgebase) and would like to use this Lightbox plugin. 
Therefor I added a new line to activate / deactivate the Lightbox plugin. 
Perhaps you can also add an if-then-else to check if the PA_Knowledgebase is installed. 
