### PR TITLE
Fix undefined variable in `get_plugin_base_file`

### DIFF
--- a/includes/class.utilities.php
+++ b/includes/class.utilities.php
@@ -1296,8 +1296,8 @@ class SLB_Utilities {
 	 * @return string Base file path
 	 */
 	function get_plugin_base_file() {
-		$ret = $this->_plugin['file'];
-		if ( empty($ret) ) {
+		$file = $this->_plugin['file'];
+		if ( empty($file) ) {
 			$dir = @opendir($this->get_path_base());
 			if ( $dir ) {
 				while ( ($ftemp = readdir($dir)) !== false ) {


### PR DESCRIPTION
There's a problem in `get_plugin_base_file` and it only works when there's no predefined data. Once data has been obtained once , it doesn't work anymore, because it returns the wrong variable.