### PR TITLE
Add image title attribute as fallback

### DIFF
--- a/client/js/dev/lib.view.js
+++ b/client/js/dev/lib.view.js
@@ -3065,8 +3065,13 @@ var Content_Item = {
 		
 		// Fallbacks
 		if ( !title && dom.length ) {
+			// Title attribute
+			title = dom.find('img').first().attr('title');
+
 			// Alt attribute
-			title = dom.find('img').first().attr('alt');
+			if ( !title ) {
+				title = dom.find('img').first().attr('alt');
+			}
 			
 			// Element text
 			if ( !title ) {


### PR DESCRIPTION
I recently switched my blog to simple-lightbox from another (now outdated) Wordpress plugin. The other plugin always displayed the image title attribute as a caption in the lightbox, hence in all my posts I only used the image title attribute, which is not yet recognized by simple lightbox. This PR adds the image title as a default fallback for the caption in the lightbox.

A point of notice: This changes the default behavior of this plugin, since it adds the image title as a _default_ fallback prioritized over some of the current fallbacks. I think this is the correct behavior, since the title attribute is semantically more equivalent to the caption in the lightbox than e.g. the alt attribute. But since this would result in different behavior than currently, it might be a point of discussion as to add the title attribute as the very last fallback in order to keep things consistent for existing users.

If this PR is accepted, this page in the Wiki needs to be adapted as well: https://github.com/archetyped/simple-lightbox/wiki/Metadata#title-precedence.