### PR TITLE
Fix PHP Deprecation warnings in PHP8+

### DIFF
--- a/includes/class.field_type.php
+++ b/includes/class.field_type.php
@@ -432,7 +432,7 @@ class SLB_Field_Type extends SLB_Field_Base {
 				// Iterate through instances of current placeholder
 				foreach ( $instances as $instance ) {
 					// Process value based on placeholder name.
-					$target_property = $this->util->apply_filters_ref_array( "process_placeholder_${tag}", [ '', $this, &$instance, $layout, $data ], false );
+					$target_property = $this->util->apply_filters_ref_array( "process_placeholder_{$tag}", [ '', $this, &$instance, $layout, $data ], false );
 					// Process value using default processors (if necessary).
 					if ( '' === $target_property ) {
 						$target_property = $this->util->apply_filters_ref_array( 'process_placeholder', [ $target_property, $this, &$instance, $layout, $data ], false );

--- a/includes/class.options.php
+++ b/includes/class.options.php
@@ -498,7 +498,7 @@ class SLB_Options extends SLB_Field_Collection {
 	function &add( $id, $properties = array(), $update = false ) {
 		// Create item
 		$args = func_get_args();
-		$ret  = call_user_func_array( array( 'parent', 'add' ), $args );
+		$ret  = call_user_func_array( array( parent::class, 'add' ), $args );
 		return $ret;
 	}
 

--- a/includes/class.utilities.php
+++ b/includes/class.utilities.php
@@ -542,7 +542,9 @@ class SLB_Utilities {
 
 		// Build condition
 		$sep = '.';
+		$obj = $obj ? $obj : '';
 		$obj = trim( $obj, $sep );
+
 		//  Strip base object
 		if ( 0 === strpos( $obj, $base . $sep ) ) {
 			$obj = substr( $obj, strlen( $base . $sep ) );


### PR DESCRIPTION
PHP 8.1 & 8.2 issue some deprecation notices when using Simple Lightbox.
This fixes those warnings without changing functionality.