### PR TITLE
Fixes PHP 8.2+ deprecation warning: "Use of 'parent' in callables is deprecated"

### DIFF
--- a/includes/class.options.php
+++ b/includes/class.options.php
@@ -498,7 +498,7 @@ class SLB_Options extends SLB_Field_Collection {
 	function &add( $id, $properties = array(), $update = false ) {
 		// Create item
 		$args = func_get_args();
-		$ret  = call_user_func_array( array( 'parent', 'add' ), $args );
+		$ret  = parent::add( ...$args );
 		return $ret;
 	}
 


### PR DESCRIPTION
Fixes PHP 8.2+ deprecation warning: "Use of 'parent' in callables is deprecated"

## Changes

- Replace deprecated `call_user_func_array( array( 'parent', 'add' ), $args )` with `parent::add( ...$args )` in `class.options.php`

## Technical Details

PHP 8.2 deprecated the use of `'parent'`, `'self'`, and `'static'` strings in callables passed to functions like `call_user_func_array()`. This change uses the direct `parent::` syntax with the spread operator, which is:

- Supported since PHP 5.6 (plugin minimum requirement)
- Functionally equivalent to the previous implementation
- Future-proof for PHP 9.0 where this will become a fatal error

## Testing

- [x] Verified syntax with `php -l`
- [x] Tested plugin activation on PHP 8.2+
- [x] Verified options page loads correctly
- [x] Verified lightbox functionality works
- [x] Confirmed no deprecation warnings in error logs
- [x] Ran Grunt build successfully

## Files Changed

- `includes/class.options.php` (1 line)

## Related

- PHP RFC: https://wiki.php.net/rfc/deprecate_partially_supported_callables
```
