### PR TITLE
Avoid an HTTP loopback request

### DIFF
--- a/includes/class.base_object.php
+++ b/includes/class.base_object.php
@@ -254,9 +254,18 @@ class SLB_Base_Object extends SLB_Base {
 					break;
 				case 'contents':
 					$ret = $ret['uri'];
+					// Try reading from local filesystem to avoid an HTTP loopback request.
 					if ( ! $this->util->is_uri( $ret ) ) {
+						$path = $this->util->get_relative_path( $ret );
+						$path = $this->util->normalize_path( ABSPATH, $path );
+						$real = realpath( $path );
+						if ( $real && strpos( wp_normalize_path( $real ), wp_normalize_path( WP_CONTENT_DIR ) ) === 0 ) {
+							$ret = file_get_contents( $real );
+							break;
+						}
 						$ret = $this->util->normalize_path( site_url(), $ret );
 					}
+					// Fallback to HTTP request (e.g. remote/non-local storage).
 					$get = wp_safe_remote_get( $ret );
 					$ret = ( ! is_wp_error( $get ) && 200 === $get['response']['code'] ) ? $get['body'] : '';
 					break;


### PR DESCRIPTION
Fixes #387.

The HTTP loopback in `get_file_contents()` caused a significant server load for me.

The `contents` case in `get_file_contents()` uses `wp_safe_remote_get()` to fetch local plugin files (e.g. `themes/baseline/layout.html`). Since the URI is relative, it gets resolved to a URL on the same server and fetched over HTTP, triggering a full WordPress bootstrap (plugins, MySQL queries, Apache worker) just to read a local file.

This effectively **doubles the cost of every uncached page view**: each request occupies two web server workers and runs the full WordPress stack twice. Under moderate traffic, the worker pool fills up twice as fast, causing cascading delays.

On a server I manage (2 CPUs, 1 GB RAM), this was the primary cause of load spikes exceeding 13x CPU capacity (due to request queuing and cascading congestion). Eliminating the loopback immediately halved the server load.